### PR TITLE
Fix typo in defining-chemical-systems.ipynb

### DIFF
--- a/tutorials/basics/defining-chemical-systems.ipynb
+++ b/tutorials/basics/defining-chemical-systems.ipynb
@@ -105,7 +105,7 @@
             "metadata": {},
             "source": [
                 "```{note}\n",
-                "Reaktoro has default names for phases, such as `AqueousPhase` and `GaseousPhase`` for aqueous and gaseous phases. For pure mineral phases, the phase name is the same as the name of the mineral species composing it. That's is why the mineral phase above is named `Halite`, whose only composing species is called `Halite`. Note also that Reaktoro supports as many phases as you wish, each phase containing any number of species. We will demonstrate this in subsequent tutorials.\n",
+                "Reaktoro has default names for phases, such as `AqueousPhase` and `GaseousPhase` for aqueous and gaseous phases. For pure mineral phases, the phase name is the same as the name of the mineral species composing it. That's is why the mineral phase above is named `Halite`, whose only composing species is called `Halite`. Note also that Reaktoro supports as many phases as you wish, each phase containing any number of species. We will demonstrate this in subsequent tutorials.\n",
                 "```\n",
                 "\n",
                 "We can also inspect how the chemical species are ordered in the system:"


### PR DESCRIPTION
Fix Markdown formatting typo.

Maybe there could be some auto-checker for this in the docs build?